### PR TITLE
support for gzipped ndjson files

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ npm run build -- -r [data-directory] -p [fhir-definition-directory]
 
 | Parameter | Short | Cardinality | Description |
 | - | -| - | - |
-| resources | r | 0..* | Path to a directory of FHIR resource files or a single FHIR resource file. File(s) may be FHIR Bundles in json format or FHIR Bulk Data files in ndjson format. Defaults to current directory. |
+| resources | r | 0..* | Path to a directory of FHIR resource files or a single FHIR resource file. File(s) may be FHIR Bundles in json format or FHIR Bulk Data files in ndjson format. Bulk ndjson files may optionally be gzipped. Defaults to current directory. |
 | profiles | p | 0..* | Path to FHIR profiles (`profiles-resources.json` and `profiles-types.json`). Census will attempt to impute some field types if this parameter is omitted. |
 | output | o | 0..1 | Output folder path (file will be created as `summary.json`) or path to a specific file name with a `.json` extension. Defaults to current directory. | 
 | stratify-by | s | 0..* | Stratification functions. Defaults to `obs_cat` to stratify Observation resources by category (pass a value of `none` to skip all stratification). See details below. |

--- a/builder/src/summarizer.js
+++ b/builder/src/summarizer.js
@@ -1,6 +1,8 @@
 const _ = require("lodash");
 const path = require("path");
 const fs = require("fs");
+const zlib = require('zlib');
+const readline = require('readline');
 const LineByLineReader = require('line-by-line');
 
 const builder = require("./build-definitions");
@@ -256,6 +258,23 @@ function flattenSummary(data) {
 	return {summary: flatSummary, detail: flatDetail};
 }
 
+function summarizeNDJSONGzip(filePath, definitions, stratifyFn, summary={}, skipDetails) {
+	return new Promise( (resolve, reject) => {
+		const rs = fs.createReadStream(filePath);
+		const gunzip = zlib.createGunzip();
+		const lr = readline.createInterface(rs.pipe(gunzip));
+		lr.on('error', err => {
+			lr.close();
+			reject(err);
+		});
+		lr.on('line', line => {
+			const resource = JSON.parse(line);
+			summarizeResource(resource, definitions, stratifyFn, summary, skipDetails);
+		});
+		lr.on('close', () => resolve(summary) );
+	});
+}
+
 function summarizeBundle(filePath, definitions, stratifyFn, summary={}, skipDetails) {
 	return new Promise( (resolve, reject) => {
 		try {
@@ -288,4 +307,4 @@ function summarizeNDJSON(filePath, definitions, stratifyFn, summary={}, skipDeta
 	});
 }
 
-module.exports = { pathToFhirType, summarizeResource, summarizeNDJSON, summarizeBundle, flattenSummary, buildDefinitions };
+module.exports = { pathToFhirType, summarizeResource, summarizeNDJSON, summarizeNDJSONGzip, summarizeBundle, flattenSummary, buildDefinitions };


### PR DESCRIPTION
Allows NDJSON bulk export files to (optionally) be gzip-compressed. Detected based on `.gz` file extension, similarly to how .json Bundles / .ndjson bulk exports are being identified now. Tested on a 5k patient export split into multiple gzipped ndjson files, confirmed the output to be unchanged. Let me know what you think, or if you have any suggestions about how it could be better implemented!